### PR TITLE
Link to the Lwt project from the text

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 The following people - listed in alphabetical order - contributed to [Concurrent Programming with Lwt](https://github.com/dkim/rwo-lwt):
 
+* [Anton Bachin](https://github.com/aantron)
 * [Deokhwan Kim](https://github.com/dkim)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Deokhwan Kim - Version v1.0, 2017-05-09
 
-Below are Lwt translations of [the code examples](https://github.com/realworldocaml/examples) in [Real World OCaml - Chapter 18. Concurrent Programming with Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html). The section titles follow those in the book for easy cross-reference. Here is the version information of the software components that I have used:
+Below are [Lwt](https://github.com/ocsigen/lwt) translations of [the code examples](https://github.com/realworldocaml/examples) in [Real World OCaml - Chapter 18. Concurrent Programming with Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html). The section titles follow those in the book for easy cross-reference. Here is the version information of the software components that I have used:
 
 ```bash
 $ ocamlc -version


### PR DESCRIPTION
This makes it easy to visit the project page, including to find more documentation.